### PR TITLE
Bumped LibreOffice to 4.0.4.2

### DIFF
--- a/libreoffice/libreoffice.nuspec
+++ b/libreoffice/libreoffice.nuspec
@@ -1,9 +1,9 @@
-<?xml version="1.0"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>libreoffice</id>
     <title>LibreOffice</title>
-    <version>4.0.3.3</version>
+    <version>4.0.4.2</version>
     <authors>LibreOffice Developer</authors>
     <owners>Yoshimov</owners>
     <summary>LibreOffice is the free power-packed Open Source personal productivity suite for Windows, Macintosh and Linux, that gives you six feature-rich applications for all your document production and data processing needs.</summary>

--- a/libreoffice/tools/chocolateyInstall.ps1
+++ b/libreoffice/tools/chocolateyInstall.ps1
@@ -1,10 +1,10 @@
 ﻿try {
-  $clsid='{F77ED0CD-2E5E-4FC7-82E0-BB7D461E739F}'
-  if (Test-Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$clsid") {
-    Write-ChocolateyFailure 'libreoffice' "Libre office is already installed!"
+  $clsid='{FE88323B-9F0E-4596-8F56-37757C6918E9}'
+  if ((Test-Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$clsid") -or (Test-Path "HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\$clsid")) {
+    Write-Host "LibreOffice is already installed!"
   }
   else {
-    $downUrl = 'http://download.documentfoundation.org/libreoffice/stable/4.0.3/win/x86/LibreOffice_4.0.3_Win_x86.msi'
+    $downUrl = 'http://download.documentfoundation.org/libreoffice/stable/4.0.4/win/x86/LibreOffice_4.0.4_Win_x86.msi'
     # installer, will assert administrative rights
     Install-ChocolateyPackage 'libreoffice' 'MSI' '/passive' "$downUrl" -validExitCodes @(0)
     # the following is all part of error handling

--- a/libreoffice/tools/chocolateyUninstall.ps1
+++ b/libreoffice/tools/chocolateyUninstall.ps1
@@ -1,5 +1,5 @@
 ﻿try {
-  $clsid='{F77ED0CD-2E5E-4FC7-82E0-BB7D461E739F}'
+  $clsid='{FE88323B-9F0E-4596-8F56-37757C6918E9}'
   Uninstall-ChocolateyPackage 'libreoffice' 'MSI' "$clsid" -validExitCodes @(0)
   
   # the following is all part of error handling


### PR DESCRIPTION
It is better to not display an error when Libreoffice is already installed, because otherwise Chocolatey would stop on that error. If a user did a `cup all`, it would stop updating the other packages. That is annoying.
