### PR TITLE
bumped ultravnc to v1.1.9.1

### DIFF
--- a/ultravnc/tools/chocolateyInstall.ps1
+++ b/ultravnc/tools/chocolateyInstall.ps1
@@ -1,6 +1,6 @@
 ﻿try {
-  $downUrl = 'http://www.uvnc.eu/download/1190/UltraVNC_1_1_9_X86_Setup.exe'
-  $down64Url = 'http://www.uvnc.eu/download/1190/UltraVNC_1_1_9_X64_Setup.exe'
+  $downUrl = 'http://support1.uvnc.com/download/1190/UltraVNC_1_1_9_X86_Setup.exe'
+  $down64Url = 'http://support1.uvnc.com/download/1190/UltraVNC_1_1_9_X64_Setup.exe'
 
   # installer, will assert administrative rights
   Install-ChocolateyPackage 'ultravnc' 'EXE' '/SILENT' "$downUrl" "$down64Url" -validExitCodes @(0)

--- a/ultravnc/ultravnc.nuspec
+++ b/ultravnc/ultravnc.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>ultravnc</id>
     <title>UltraVNC</title>
-    <version>1.1900</version>
+    <version>1.1.9.1</version>
     <authors>uvnc</authors>
     <owners>Yoshimov</owners>
     <summary>UltraVNC is a powerful, easy to use and free software that can display the screen of another computer (via internet or network) on your own screen.</summary>
@@ -13,7 +13,7 @@
     <copyright></copyright>
     <licenseUrl>http://www.uvnc.com/</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <!--<iconUrl>https://github.com/yoshimov/chocolatey-packages/raw/master/ultravnc/ultravnc.png</iconUrl>-->
+    <iconUrl>https://github.com/yoshimov/chocolatey-packages/raw/master/ultravnc/ultravnc.png</iconUrl>
     <!--<dependencies>
       <dependency id="" version="" />
     </dependencies>-->


### PR DESCRIPTION
- Old download links weren’t working, replaced with new ones
- Uncommented iconUrl-tag
- Corrected version to match official versioning. In order that you can push this new and correct version of UltraVNC you first must unlist all older versions of your UltraVNC package in the choco gallery.
