### PR TITLE
Update scala.nuspec

### DIFF
--- a/scala/scala.nuspec
+++ b/scala/scala.nuspec
@@ -16,6 +16,7 @@
     <iconUrl>https://github.com/yoshimov/chocolatey-packages/raw/master/scala/logo.png</iconUrl>
     <dependencies>
       <dependency id="binroot" version="" />
+      <dependency id="javaruntime" version="[6.0,8.0)" />
     </dependencies>
     <releaseNotes></releaseNotes>
   </metadata>


### PR DESCRIPTION
The scala installer depends on java runtime >= 1.6. I like to be conservative, in my old age, so I capped it at < 8.0.
