### PR TITLE
H2Databse : Updating URL and version to the last stable

### DIFF
--- a/h2database/h2database.nuspec
+++ b/h2database/h2database.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>h2database</id>
     <title>H2 Database Engine</title>
-    <version>1.3.169</version>
+    <version>1.3.176</version>
     <authors>Thomas Mueller</authors>
     <owners>Yoshimov</owners>
     <summary>H2 is the Java SQL database which is very fast, open source, JDBC API, embeddable and small footprint.</summary>

--- a/h2database/tools/chocolateyInstall.ps1
+++ b/h2database/tools/chocolateyInstall.ps1
@@ -1,5 +1,5 @@
 ﻿#try {
-  $downUrl = 'http://www.h2database.com/h2-setup-2012-07-13.exe'
+  $downUrl = 'http://www.h2database.com/h2-setup-2014-04-05.exe'
   Install-ChocolateyPackage 'h2database' 'EXE' '/S' "$downUrl" -validExitCodes @(0)
 
   #Write-ChocolateySuccess 'h2database'


### PR DESCRIPTION
The version 1.3.169 of H2Databse is no more available, we got a 404 when fetched : 
`Write-Error : Package 'h2database v1.3.169' did not install successfully: Exception calling "GetResponse" with "0" argument(s): "The remote server re
turned an error: (404) Not Found."`

The updated URL with the last stable version (1.3.176) will correct the 404...

Regards,
Xavier
