### PR TITLE
Add jre8 deps to freemind

### DIFF
--- a/automatic/freemind/freemind.nuspec
+++ b/automatic/freemind/freemind.nuspec
@@ -14,9 +14,9 @@
     <licenseUrl>http://freemind.sourceforge.net/wiki/index.php/Main_Page#License</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <iconUrl>https://raw.github.com/yoshimov/chocolatey-packages/master/automatic/freemind/freemind.png</iconUrl>
-    <!--<dependencies>
-      <dependency id="" version="" />
-    </dependencies>-->
+    <dependencies>
+      <dependency id="jre8"/>
+    </dependencies>
     <releaseNotes></releaseNotes>
   </metadata>
   <files>


### PR DESCRIPTION
This PR adds for freemind package:
```
    <dependencies>
      <dependency id="jre8"/>
    </dependencies>

```

Without this change, installation is blocked during "choco install -y freemind" with popup:
<img width="501" alt="pasted_image_19_02_2017__01_36" src="https://cloud.githubusercontent.com/assets/12024504/23098031/f497d274-f643-11e6-9cca-e3cf5d242736.png">

HTH
Jean-Pierre

