### PR TITLE
Bumped version to 1.15.2 and removed warnings

### DIFF
--- a/carotdav/carotdav.nuspec
+++ b/carotdav/carotdav.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>carotdav</id>
     <title>CarotDAV</title>
-    <version>1.9.9</version>
+    <version>1.15.2</version>
     <authors>Hobara Rei</authors>
     <owners>Yoshimov</owners>
     <summary>CarotDAV is a simple network storage client for WebDAV, Google Drive, Dropbox, etc.</summary>

--- a/carotdav/tools/chocolateyInstall.ps1
+++ b/carotdav/tools/chocolateyInstall.ps1
@@ -1,11 +1,9 @@
-﻿try {
-  $pkgid='carotdav'
-  $downUrl = 'http://rei.to/CarotDAV1.9.9.portable.zip'
-  $installDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)" 
-  # installer, will assert administrative rights
-  Install-ChocolateyZipPackage "$pkgid" "$downUrl" "$installDir"
-  Write-ChocolateySuccess "$pkgid"
-} catch {
-  Write-ChocolateyFailure "$pkgid" "$($_.Exception.Message)"
-  throw 
-}
+﻿$pkgid='carotdav'
+$downUrl = 'http://rei.to/CarotDAV1.15.2.portable.zip'
+$installDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)" 
+$checksumType = "SHA1"
+$checkSum = "f140684ea59f41755f2f9a9007bc99f41d367587"
+# installer, will assert administrative rights
+Install-ChocolateyZipPackage "$pkgid" "$downUrl" "$installDir" -ChecksumType $checksumType -Checksum $checkSum
+Install-ChocolateyDesktopLink (Join-Path $installDir 'CarotDAV\CarotDAV.exe')
+Install-ChocolateyDesktopLink (Join-Path $installDir 'CarotDAV\CarotDAVC.exe')


### PR DESCRIPTION
- Bumped version to 1.15.2
- removed the Write-ChocolateySuccess - warning (removed try/catch completely)
- added DesktopLinks